### PR TITLE
Wait for end of child load process before finishing the data loader

### DIFF
--- a/src/crystal-sync/data_loader.cr
+++ b/src/crystal-sync/data_loader.cr
@@ -1,9 +1,10 @@
 class DataLoader
   @table_buffer : IO
+  @process: Process
 
   def initialize(@db : Db, @table_name : String, columns : Array(String))
     @i = 0
-    @table_buffer = @db.table_from_csv(table_name)
+    @table_buffer, @process = @db.table_from_csv(table_name)
     @csv = NullableCSVBuilder.new(@table_buffer)
     @csv.row columns
   end
@@ -16,6 +17,7 @@ class DataLoader
 
   def done
     @table_buffer.close
+    @process.wait
   end
 
   private def placeholder

--- a/src/crystal-sync/db/driver/none.cr
+++ b/src/crystal-sync/db/driver/none.cr
@@ -11,5 +11,5 @@ class Db::Driver::None < Db::Driver
   def placeholder_type; PlaceholderType::Questionmark; end
   def escape_table_name(name : String) : String; ""; end
   def table_as_csv(table_name : String, &block); end
-  def table_from_csv(table_name : String) : IO; IO::Memory.new; end
+  def table_from_csv(table_name : String) : {IO, Process}; return IO::Memory.new, Process.new("echo"); end
 end

--- a/src/crystal-sync/db/driver/postgres.cr
+++ b/src/crystal-sync/db/driver/postgres.cr
@@ -97,15 +97,15 @@ class Db::Driver::Postgres < Db::Driver
     end
   end
 
-  def table_from_csv(table_name : String) : IO
+  def table_from_csv(table_name : String) : {IO, Process}
     read, write = IO.pipe
-    Process.new(
+    process = Process.new(
       "psql #{@db.uri} -a -c \"COPY #{table_name} FROM STDIN WITH (FORMAT csv, HEADER true, NULL '\\N')\"",
       shell: true,
       input: read,
       error: STDERR
     )
-    write
+    return write, process
   end
 
   private def dump_tables(buffer : IO)


### PR DESCRIPTION
This prevents missing data at the end of a load.